### PR TITLE
Add u-boot-tegra deploy dependency to tegra186-flash-dry:do_compile

### DIFF
--- a/layers/meta-resin-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_28.2.0.bb
+++ b/layers/meta-resin-jetson/recipes-bsp/tegra-binaries/tegra186-flash-dry_28.2.0.bb
@@ -190,6 +190,7 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 
 do_configure[depends] += "tegra-binaries:do_preconfigure"
 do_compile[depends] += "virtual/kernel:do_deploy"
+do_compile[depends] += "u-boot-tegra:do_deploy"
 do_install[depends] += "virtual/kernel:do_deploy"
 do_populate_lic[depends] += "tegra-binaries:do_unpack"
 


### PR DESCRIPTION
[resin-os/resin-jetson-tx2#81]

The compilation task of tegra186-flash-dry depends on deployment of
u-boot-dtb.bin, resuting in intermittent failures of the build process.
This change reflects this dependancy.

Signed-off-by: Joe Developer <joe.developer@example.com>